### PR TITLE
Fix getting the SSID via shell

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/TunnelExtensions.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/TunnelExtensions.kt
@@ -84,7 +84,7 @@ fun Config.toWgQuickString(): String {
 
 fun RootShell.getCurrentWifiName(): String? {
 	val response = mutableListOf<String>()
-	this.run(response, "dumpsys wifi | grep -o \"SSID: [^,]*\" | cut -d ' ' -f2- | tr -d '\"'")
+	this.run(response, "dumpsys wifi | grep 'Supplicant state: COMPLETED' | grep -o 'SSID: [^,]*' | cut -d ' ' -f2- | head -n1 | tr -d '\"'")
 	return response.lastOrNull()
 }
 

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/TunnelExtensions.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/extensions/TunnelExtensions.kt
@@ -84,8 +84,8 @@ fun Config.toWgQuickString(): String {
 
 fun RootShell.getCurrentWifiName(): String? {
 	val response = mutableListOf<String>()
-	this.run(response, "dumpsys wifi | grep 'Supplicant state: COMPLETED' | grep -o 'SSID: [^,]*' | cut -d ' ' -f2- | head -n1 | tr -d '\"'")
-	return response.lastOrNull()
+	this.run(response, "dumpsys wifi | grep 'Supplicant state: COMPLETED' | grep -o 'SSID: [^,]*' | cut -d ' ' -f2- | tr -d '\"'")
+	return response.firstOrNull()
 }
 
 fun Backend.BackendState.asBackendState(): BackendState {


### PR DESCRIPTION
I've fixed the command to get the current SSID via the root shell. Previously it was using the last line of the output, which in my case was a remembered network name, but not the currently connected one. I've tested the old and new commands on a few smartphones (via adb):
|| Old | New |
|--------|--------|--------|
| Samsung, 4.1.2 | ❌ | ❌ |
| Sony, 4.1.2 | ❌ | ✔️ |
| Huawei, 8.1.0 | ❌ | ✔️ |
| LineageOS, 12.0 | ❌ | ✔️ |

Please keep in mind: 708b4c7646748c5b41c3168f567c46565e37f36a introduces a regression that prevents root SSID functionality from working entirely. I've figured out that `isWifiNameByShellEnabled` in `getWifiSSID()` is `false` with this change applied and `true` without it, but wasn't able to figure out why. Removing `.filterNot { it.isWifiConnected && it.wifiName == null }` entirely fixes the issue, but I did not include it in this PR because it likely undoes the fix for #472. I can open a new issue for this if you'd like.