### PR TITLE
Address https://github.com/wgtunnel/wgtunnel/issues/956

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/components/TunnelStatisticsRow.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/tunnels/components/TunnelStatisticsRow.kt
@@ -46,7 +46,13 @@ fun TunnelStatisticsRow(
                         peer.publicKey.toBase64().subSequence(0, 3).toString() + "***"
                     }
                 val endpoint by
-                    remember(peerStats) { derivedStateOf { peerStats?.resolvedEndpoint } }
+                    remember(peerStats, peer) { 
+                        derivedStateOf { 
+                            // Display original configured endpoint if present, fallback to resolved
+                            peer.endpoint.takeIf { it.isPresent }?.get()?.toString() 
+                                ?: peerStats?.resolvedEndpoint 
+                        } 
+                    }
                 val peerRxMB by
                     remember(peerStats) {
                         derivedStateOf {


### PR DESCRIPTION
1. Prioritizes Original Configuration: Now displays the original FQDN that the user configured (e.g., 'myhomefqdn.net')
2. Maintains Fallback: If no original endpoint is available, it falls back to the resolved IP address
3. Preserves Functionality: All existing functionality remains intact
4. Memory Dependencies: Added peer to the remember dependencies to ensure proper recomposition when peer data changes

Expected Behavior After Fix:

- When users configure tunnels with FQDNs like 'myhomefqdn.net:51820', the home screen will now display 'myhomefqdn.net:51820' instead of the resolved IP '174.1.2.3:51820'
- If a tunnel was configured with an IP address, it will continue to show the IP address as before
- The underlying VPN functionality remains unchanged - only the display is affected

This minimal change directly addresses the user's complaint in issue #956 while maintaining backward compatibility and system functionality.