### PR TITLE
feat: support for filtering by endpoint latency

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/common/ExpandingRowListItem.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/common/ExpandingRowListItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -17,7 +18,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ExpandingRowListItem(
     leading: @Composable () -> Unit,
-    text: String,
+    text: AnnotatedString,
     trailing: @Composable () -> Unit,
     isSelected: Boolean,
     expanded: @Composable () -> Unit,

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/components/currentBackStackEntryAsNavbarState.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/navigation/components/currentBackStackEntryAsNavbarState.kt
@@ -220,6 +220,16 @@ fun currentRouteAsNavbarState(
                             Row {
                                 IconButton(
                                     onClick = {
+                                        sharedViewModel.postSideEffect(LocalSideEffect.SortByLatency)
+                                    }
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.NetworkCheck,
+                                        stringResource(R.string.sort_by_latency),
+                                    )
+                                }
+                                IconButton(
+                                    onClick = {
                                         sharedViewModel.postSideEffect(LocalSideEffect.Sort)
                                     }
                                 ) {

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/sideeffect/LocalSideEffect.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/sideeffect/LocalSideEffect.kt
@@ -1,7 +1,14 @@
 package com.zaneschepke.wireguardautotunnel.ui.sideeffect
 
+import com.zaneschepke.wireguardautotunnel.domain.model.TunnelConfig
+
 sealed class LocalSideEffect {
     data object Sort : LocalSideEffect()
+    data object SortByLatency : LocalSideEffect()
+    data class LatencySortFinished(
+        val tunnels: List<TunnelConfig>,
+        val latencies: Map<Int, Double>,
+    ) : LocalSideEffect()
 
     data object SaveChanges : LocalSideEffect()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,8 @@
     <string name="release_notes">Release notes</string>
     <string name="shizuku_not_detected">Shizuku not detected</string>
     <string name="sort">Sort</string>
+    <string name="sort_by_latency">Sort by latency</string>
+    <string name="pinging_servers">Pinging servers…</string>
     <string name="drag_handle">Drag Handle</string>
     <string name="move_up">Move Up</string>
     <string name="move_down">Move Down</string>


### PR DESCRIPTION
Closes #1150

Hello! This is my first PR in this project, so hopefully this provides all the information you need. Please let me know if you have a preferred approach to these sorts of contributions so I can accommodate.

This PR introduces a new "Sort by Latency" feature in the tunnel management screen. It allows for users to automatically sort configured tunnels based on ping response times, making it easy to select the 'fastest' available connection.

As I mentioned in the linked FR, this is particularly useful for users (such as myself) who download configuration files from a VPN provider, who oftentimes provide a ZIP of all their servers. Importing all of these creates some clutter. It's good to have choice, but realistically I'm not going to be connecting to servers on the other side of the planet. The ability to sort by latency allows a user to see the servers they are most likely to access first.

Key change overview:
* Added parallel pinging logic in `SharedAppViewModel` to check latency for all configured tunnels simultaneously.
* Updated `sortScreen` to display latency values next to configured tunnel names.
* Added color-coded feedback based on latency response times (green < 50ms, yellow < 150ms, red > 150ms.
* Refactored `ExpandingRowListItem` to support `AnnotatedString` (enabling the above). I've confirmed `SortScreen` is the only consumer of this component so this should not affect anything else.
* Added `SortByLatency` and `LatencySortFinished` side effects to handle the async sorting flow.

I have been running this build for a couple of days and have found myself using it more than I'd actually expected, might be placebo of course as I am consciously making sure the change works, but I did find myself wanting to use it to connect to the closest available endpoint as I switched between various networks / mobile connections.

<img width="240" alt="image" src="https://github.com/user-attachments/assets/6c125d1a-cf6f-4854-8af1-1b0db80783c1" />
<img width="240" alt="image" src="https://github.com/user-attachments/assets/8b1b0c80-1ddf-4cee-b39a-4ffc108b28f2" />
<img width="240" alt="image" src="https://github.com/user-attachments/assets/14d13b67-344e-4754-af10-06839c6bdb4d" />
