### PR TITLE
fix(tunnel): add LAN bypass mode for Android Auto wireless compatibility

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/tunnel/backend/RunConfigHelper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/tunnel/backend/RunConfigHelper.kt
@@ -11,11 +11,13 @@ import com.zaneschepke.wireguardautotunnel.domain.repository.DnsSettingsReposito
 import com.zaneschepke.wireguardautotunnel.domain.repository.GeneralSettingRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.ProxySettingsRepository
 import com.zaneschepke.wireguardautotunnel.domain.repository.TunnelRepository
+import com.zaneschepke.wireguardautotunnel.util.network.CidrUtils
 import java.util.Optional
 import kotlinx.coroutines.flow.firstOrNull
 import org.amnezia.awg.config.Config
 import org.amnezia.awg.config.proxy.HttpProxy
 import org.amnezia.awg.config.proxy.Socks5Proxy
+
 
 class RunConfigHelper(
     private val settingsRepository: GeneralSettingRepository,
@@ -50,6 +52,37 @@ class RunConfigHelper(
         return PrepResult(effectiveConfig, generalSettings, dnsSettings)
     }
 
+    /**
+     * Rewrites the AllowedIPs lines of a wg-quick / awg-quick config string so that all
+     * LAN_EXCLUDED_RANGES (private/link-local subnets) are removed from each peer's AllowedIPs.
+     *
+     * This is the key mechanism for Android Auto / LAN bypass: after the transformation,
+     * WireGuard's VpnService.Builder.addRoute() will NOT add routes for 192.168.x.x etc.,
+     * so those packets bypass the TUN interface and travel directly over the physical WiFi.
+     */
+    private fun applyLanBypassToQuickConfig(quickConfig: String): String {
+        return quickConfig.lines().joinToString("\n") { line ->
+            val trimmed = line.trim()
+            if (trimmed.startsWith("AllowedIPs", ignoreCase = true)) {
+                val value = trimmed.substringAfter("=").trim()
+                val originalCidrs =
+                    value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+                val ipv4Cidrs = originalCidrs.filter { !it.contains(":") }
+                val ipv6Cidrs = originalCidrs.filter { it.contains(":") }
+
+                val lanBypassed =
+                    CidrUtils.applyLanBypass(ipv4Cidrs, TunnelConfig.LAN_EXCLUDED_RANGES)
+
+                // Preserve original line indentation
+                val indent = line.takeWhile { it.isWhitespace() }
+                "${indent}AllowedIPs = ${(lanBypassed + ipv6Cidrs).joinToString(", ")}"
+            } else {
+                line
+            }
+        }
+    }
+
     suspend fun buildAmRunConfig(tunnelConfig: TunnelConfig): Config {
         val prep = prepare(tunnelConfig)
         val proxies =
@@ -80,7 +113,20 @@ class RunConfigHelper(
             } else {
                 emptyList()
             }
-        val amConfig = prep.effectiveConfig.toAmConfig()
+        val effectiveQuickStr =
+            if (prep.generalSettings.isLanBypassEnabled) {
+                val original =
+                    prep.effectiveConfig.amQuick.ifBlank { prep.effectiveConfig.wgQuick }
+                applyLanBypassToQuickConfig(original)
+            } else null
+
+        val amConfig =
+            if (effectiveQuickStr != null) {
+                TunnelConfig.configFromAmQuick(effectiveQuickStr)
+            } else {
+                prep.effectiveConfig.toAmConfig()
+            }
+
         return Config.Builder()
             .setInterface(amConfig.`interface`)
             .addPeers(amConfig.peers)
@@ -96,6 +142,10 @@ class RunConfigHelper(
 
     suspend fun buildWgRunConfig(tunnelConfig: TunnelConfig): com.wireguard.config.Config {
         val prep = prepare(tunnelConfig)
+        if (prep.generalSettings.isLanBypassEnabled) {
+            val effectiveQuickStr = applyLanBypassToQuickConfig(prep.effectiveConfig.wgQuick)
+            return TunnelConfig.configFromWgQuick(effectiveQuickStr)
+        }
         return prep.effectiveConfig.toWgConfig()
     }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/AppDatabase.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.zaneschepke.wireguardautotunnel.data.entity.*
             DnsSettings::class,
             LockdownSettings::class,
         ],
-    version = 29,
+    version = 30,
     autoMigrations =
         [
             AutoMigration(from = 1, to = 2),
@@ -45,6 +45,7 @@ import com.zaneschepke.wireguardautotunnel.data.entity.*
             AutoMigration(from = 24, to = 25),
             AutoMigration(from = 26, to = 27, spec = GlobalsMigration::class),
             AutoMigration(from = 27, to = 28, spec = DonationMigration::class),
+            AutoMigration(from = 29, to = 30),  // Added is_lan_bypass_enabled to general_settings
         ],
     exportSchema = true,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/GeneralSettings.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/GeneralSettings.kt
@@ -27,4 +27,6 @@ data class GeneralSettings(
     @ColumnInfo(name = "is_always_on_vpn_enabled", defaultValue = "0")
     val isAlwaysOnVpnEnabled: Boolean = false,
     @ColumnInfo(name = "already_donated", defaultValue = "0") val alreadyDonated: Boolean = false,
+    @ColumnInfo(name = "is_lan_bypass_enabled", defaultValue = "0")
+    val isLanBypassEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/SettingsMapper.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/mapper/SettingsMapper.kt
@@ -19,6 +19,7 @@ fun Entity.toDomain(): Domain =
         isPinLockEnabled = isPinLockEnabled,
         isAlwaysOnVpnEnabled = isAlwaysOnVpnEnabled,
         alreadyDonated = alreadyDonated,
+        isLanBypassEnabled = isLanBypassEnabled,
     )
 
 fun Domain.toEntity(): Entity =
@@ -36,4 +37,5 @@ fun Domain.toEntity(): Entity =
         isPinLockEnabled = isPinLockEnabled,
         isAlwaysOnVpnEnabled = isAlwaysOnVpnEnabled,
         alreadyDonated = alreadyDonated,
+        isLanBypassEnabled = isLanBypassEnabled,
     )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/GeneralSettings.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/GeneralSettings.kt
@@ -18,4 +18,5 @@ data class GeneralSettings(
     val isAlwaysOnVpnEnabled: Boolean = false,
     val isKillSwitchMetered: Boolean = true,
     val alreadyDonated: Boolean = false,
+    val isLanBypassEnabled: Boolean = false,
 )

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/TunnelConfig.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/TunnelConfig.kt
@@ -250,5 +250,26 @@ data class TunnelConfig(
                 "208.0.0.0/4",
             )
         val LAN_BYPASS_ALLOWED_IPS = setOf(IPV6_ALL_NETWORKS) + IPV4_PUBLIC_NETWORKS
+
+        /**
+         * Private and link-local IPv4/IPv6 ranges that should NOT be routed through WireGuard when
+         * "LAN bypass" (Android Auto compatibility) mode is active.
+         *
+         * Covers:
+         *  - 10.0.0.0/8        RFC-1918 class A private (Android Auto hotspot variants)
+         *  - 172.16.0.0/12     RFC-1918 class B private
+         *  - 192.168.0.0/16    RFC-1918 class C private (most car WiFi hotspots)
+         *  - 169.254.0.0/16    Link-local (ARP, mDNS, APIPA)
+         *  - 224.0.0.0/4       IPv4 multicast (mDNS = 224.0.0.251)
+         */
+        val LAN_EXCLUDED_RANGES =
+            setOf(
+                "10.0.0.0/8",
+                "172.16.0.0/12",
+                "192.168.0.0/16",
+                "169.254.0.0/16",
+                "224.0.0.0/4",
+            )
+
     }
 }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/integrations/AndroidIntegrationsScreen.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/ui/screens/settings/integrations/AndroidIntegrationsScreen.kt
@@ -68,128 +68,156 @@ fun AndroidIntegrationsScreen(viewModel: SettingsViewModel = koinViewModel()) {
     }
 
     Column(
-        horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
-        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
+            modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
     ) {
         if (!isTv) {
             Column {
                 GroupLabel(stringResource(id = R.string.vpn), Modifier.padding(horizontal = 16.dp))
                 SurfaceRow(
-                    leading = {
-                        Icon(Icons.Outlined.AdminPanelSettings, contentDescription = null)
-                    },
-                    title = stringResource(R.string.native_kill_switch),
-                    trailing = { Icon(Icons.AutoMirrored.Outlined.Launch, null) },
-                    onClick = { context.launchVpnSettings() },
+                        leading = {
+                            Icon(Icons.Outlined.AdminPanelSettings, contentDescription = null)
+                        },
+                        title = stringResource(R.string.native_kill_switch),
+                        trailing = { Icon(Icons.AutoMirrored.Outlined.Launch, null) },
+                        onClick = { context.launchVpnSettings() },
                 )
                 SurfaceRow(
-                    leading = { Icon(Icons.Outlined.VpnLock, contentDescription = null) },
-                    trailing = {
-                        ThemedSwitch(
-                            checked = isAlwaysOnEnabled,
-                            onClick = { viewModel.setAlwaysOnVpnEnabled(it) },
-                        )
-                    },
-                    title = stringResource(R.string.always_on_vpn_support),
-                    onClick = { viewModel.setAlwaysOnVpnEnabled(!isAlwaysOnEnabled) },
-                    description = { DescriptionText(stringResource(R.string.aovpn_description)) },
+                        leading = { Icon(Icons.Outlined.VpnLock, contentDescription = null) },
+                        trailing = {
+                            ThemedSwitch(
+                                    checked = isAlwaysOnEnabled,
+                                    onClick = { viewModel.setAlwaysOnVpnEnabled(it) },
+                            )
+                        },
+                        title = stringResource(R.string.always_on_vpn_support),
+                        onClick = { viewModel.setAlwaysOnVpnEnabled(!isAlwaysOnEnabled) },
+                        description = {
+                            DescriptionText(stringResource(R.string.aovpn_description))
+                        },
+                )
+                SurfaceRow(
+                        leading = {
+                            Icon(Icons.Outlined.AdminPanelSettings, contentDescription = null)
+                        },
+                        trailing = {
+                            ThemedSwitch(
+                                    checked = settingsState.settings.isLanBypassEnabled,
+                                    onClick = { viewModel.setLanBypassEnabled(it) },
+                            )
+                        },
+                        title = stringResource(R.string.lan_bypass),
+                        onClick = {
+                            viewModel.setLanBypassEnabled(
+                                    !settingsState.settings.isLanBypassEnabled
+                            )
+                        },
+                        description = {
+                            DescriptionText(stringResource(R.string.lan_bypass_description))
+                        },
                 )
             }
         }
+
         Column {
             GroupLabel(
-                stringResource(id = R.string.tunnel_control),
-                Modifier.padding(horizontal = 16.dp),
+                    stringResource(id = R.string.tunnel_control),
+                    Modifier.padding(horizontal = 16.dp),
             )
             SurfaceRow(
-                leading = {
-                    Icon(
-                        Icons.Outlined.Restore,
-                        contentDescription = null,
-                        tint =
-                            if (isAlwaysOnEnabled) MaterialTheme.colorScheme.outline
-                            else MaterialTheme.colorScheme.onSurface,
-                    )
-                },
-                trailing = {
-                    ThemedSwitch(
-                        checked = settingsState.settings.isRestoreOnBootEnabled,
-                        onClick = { viewModel.setRestoreOnBootEnabled(it) },
-                        enabled = !isAlwaysOnEnabled,
-                    )
-                },
-                title = stringResource(R.string.restart_at_boot),
-                onClick = {
-                    viewModel.setRestoreOnBootEnabled(
-                        !settingsState.settings.isRestoreOnBootEnabled
-                    )
-                },
-                enabled = !isAlwaysOnEnabled,
-                description = { DescriptionText(stringResource(R.string.tunnel_boot_description)) },
+                    leading = {
+                        Icon(
+                                Icons.Outlined.Restore,
+                                contentDescription = null,
+                                tint =
+                                        if (isAlwaysOnEnabled) MaterialTheme.colorScheme.outline
+                                        else MaterialTheme.colorScheme.onSurface,
+                        )
+                    },
+                    trailing = {
+                        ThemedSwitch(
+                                checked = settingsState.settings.isRestoreOnBootEnabled,
+                                onClick = { viewModel.setRestoreOnBootEnabled(it) },
+                                enabled = !isAlwaysOnEnabled,
+                        )
+                    },
+                    title = stringResource(R.string.restart_at_boot),
+                    onClick = {
+                        viewModel.setRestoreOnBootEnabled(
+                                !settingsState.settings.isRestoreOnBootEnabled
+                        )
+                    },
+                    enabled = !isAlwaysOnEnabled,
+                    description = {
+                        DescriptionText(stringResource(R.string.tunnel_boot_description))
+                    },
             )
             SurfaceRow(
-                leading = { Icon(Icons.Filled.AppShortcut, contentDescription = null) },
-                trailing = {
-                    ThemedSwitch(
-                        checked = settingsState.settings.isShortcutsEnabled,
-                        onClick = { viewModel.setShortcutsEnabled(it) },
-                    )
-                },
-                title = stringResource(R.string.enabled_app_shortcuts),
-                onClick = {
-                    viewModel.setShortcutsEnabled(!settingsState.settings.isShortcutsEnabled)
-                },
+                    leading = { Icon(Icons.Filled.AppShortcut, contentDescription = null) },
+                    trailing = {
+                        ThemedSwitch(
+                                checked = settingsState.settings.isShortcutsEnabled,
+                                onClick = { viewModel.setShortcutsEnabled(it) },
+                        )
+                    },
+                    title = stringResource(R.string.enabled_app_shortcuts),
+                    onClick = {
+                        viewModel.setShortcutsEnabled(!settingsState.settings.isShortcutsEnabled)
+                    },
             )
             SurfaceRow(
-                leading = { Icon(Icons.Filled.SmartToy, contentDescription = null) },
-                trailing = {
-                    ThemedSwitch(
-                        checked = settingsState.isRemoteEnabled,
-                        onClick = { viewModel.setRemoteEnabled(it) },
-                    )
-                },
-                title = stringResource(R.string.enable_remote_app_control),
-                onClick = { viewModel.setRemoteEnabled(!settingsState.isRemoteEnabled) },
+                    leading = { Icon(Icons.Filled.SmartToy, contentDescription = null) },
+                    trailing = {
+                        ThemedSwitch(
+                                checked = settingsState.isRemoteEnabled,
+                                onClick = { viewModel.setRemoteEnabled(it) },
+                        )
+                    },
+                    title = stringResource(R.string.enable_remote_app_control),
+                    onClick = { viewModel.setRemoteEnabled(!settingsState.isRemoteEnabled) },
             )
             AnimatedVisibility(settingsState.isRemoteEnabled) {
                 settingsState.remoteKey?.let { key ->
                     var passwordProtected by remember { mutableStateOf(true) }
                     val keyText by
-                        remember(passwordProtected) {
-                            derivedStateOf {
-                                if (passwordProtected) "•".repeat(key.length) else key
+                            remember(passwordProtected) {
+                                derivedStateOf {
+                                    if (passwordProtected) "•".repeat(key.length) else key
+                                }
                             }
-                        }
                     SurfaceRow(
-                        leading = { Icon(Icons.Outlined.Key, contentDescription = null) },
-                        title = stringResource(R.string.remote_key),
-                        description = {
-                            Text(
-                                text = keyText,
-                                style =
-                                    MaterialTheme.typography.bodySmall.copy(
-                                        color = MaterialTheme.colorScheme.outline
-                                    ),
-                                overflow = TextOverflow.Clip,
-                            )
-                        },
-                        trailing = {
-                            Row {
-                                IconButton(onClick = { passwordProtected = !passwordProtected }) {
-                                    Icon(
-                                        Icons.Outlined.RemoveRedEye,
-                                        contentDescription = stringResource(R.string.show_password),
-                                    )
+                            leading = { Icon(Icons.Outlined.Key, contentDescription = null) },
+                            title = stringResource(R.string.remote_key),
+                            description = {
+                                Text(
+                                        text = keyText,
+                                        style =
+                                                MaterialTheme.typography.bodySmall.copy(
+                                                        color = MaterialTheme.colorScheme.outline
+                                                ),
+                                        overflow = TextOverflow.Clip,
+                                )
+                            },
+                            trailing = {
+                                Row {
+                                    IconButton(
+                                            onClick = { passwordProtected = !passwordProtected }
+                                    ) {
+                                        Icon(
+                                                Icons.Outlined.RemoveRedEye,
+                                                contentDescription =
+                                                        stringResource(R.string.show_password),
+                                        )
+                                    }
+                                    IconButton(onClick = { clipboard.copy(key) }) {
+                                        Icon(
+                                                Icons.Outlined.ContentCopy,
+                                                contentDescription = stringResource(R.string.copy),
+                                        )
+                                    }
                                 }
-                                IconButton(onClick = { clipboard.copy(key) }) {
-                                    Icon(
-                                        Icons.Outlined.ContentCopy,
-                                        contentDescription = stringResource(R.string.copy),
-                                    )
-                                }
-                            }
-                        },
+                            },
                     )
                 }
             }

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/network/CidrUtils.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/network/CidrUtils.kt
@@ -1,0 +1,151 @@
+package com.zaneschepke.wireguardautotunnel.util.network
+
+/**
+ * Utility for CIDR arithmetic.
+ *
+ * Implements IPv4 CIDR subtraction — necessary for LAN bypass: given AllowedIPs = 0.0.0.0/0, we
+ * subtract private/link-local ranges so local network traffic (Android Auto, Chromecast, NAS) is
+ * NOT captured by the WireGuard TUN interface and instead routes directly over the physical
+ * interface.
+ *
+ * Example:
+ * ```
+ * CidrUtils.applyLanBypass(listOf("0.0.0.0/0"), LAN_EXCLUDED_RANGES)
+ * // → ["0.0.0.0/5","8.0.0.0/7","11.0.0.0/8", ... all public IPs, no 192.168.x.x etc.]
+ * ```
+ */
+object CidrUtils {
+
+    /** Represents a single IPv4 CIDR block. */
+    data class Cidr(val addressInt: Int, val prefix: Int) {
+        /** First IP of this block as an unsigned long. */
+        fun firstIp(): Long = addressInt.toLong() and 0xFFFFFFFFL
+
+        /** Last IP of this block as an unsigned long. */
+        fun lastIp(): Long =
+            if (prefix == 0) 0xFFFFFFFFL else firstIp() + (1L shl (32 - prefix)) - 1
+
+        fun overlaps(other: Cidr): Boolean {
+            return firstIp() <= other.lastIp() && other.firstIp() <= lastIp()
+        }
+
+        override fun toString(): String {
+            val a = (addressInt ushr 24) and 0xFF
+            val b = (addressInt ushr 16) and 0xFF
+            val c = (addressInt ushr 8) and 0xFF
+            val d = addressInt and 0xFF
+            return "$a.$b.$c.$d/$prefix"
+        }
+    }
+
+    /** Parse a dotted-decimal CIDR string like "192.168.0.0/16". */
+    fun parse(cidr: String): Cidr {
+        val slash = cidr.indexOf('/')
+        val prefix = if (slash == -1) 32 else cidr.substring(slash + 1).toInt()
+        val addrStr = if (slash == -1) cidr else cidr.substring(0, slash)
+        val parts = addrStr.split(".")
+        require(parts.size == 4) { "Invalid IPv4 address: $addrStr" }
+        val addr =
+            parts.fold(0) { acc, octet ->
+                (acc shl 8) or octet.toInt().also { require(it in 0..255) { "Octet out of range" } }
+            }
+        return Cidr(addr, prefix)
+    }
+
+    /**
+     * Subtracts [exclude] from [source], returning the list of CIDR blocks that cover [source] but
+     * NOT [exclude].
+     */
+    fun subtract(source: Cidr, exclude: Cidr): List<Cidr> {
+        if (!source.overlaps(exclude)) return listOf(source)
+        // exclude totally encompasses source
+        if (exclude.firstIp() <= source.firstIp() && exclude.lastIp() >= source.lastIp()) {
+            return emptyList()
+        }
+
+        val result = mutableListOf<Cidr>()
+
+        // IPs before the excluded block
+        if (source.firstIp() < exclude.firstIp()) {
+            result.addAll(rangeToCidrs(source.firstIp(), exclude.firstIp() - 1))
+        }
+
+        // IPs after the excluded block
+        if (source.lastIp() > exclude.lastIp()) {
+            result.addAll(rangeToCidrs(exclude.lastIp() + 1, source.lastIp()))
+        }
+
+        return result
+    }
+
+    /**
+     * Converts a contiguous IP range [start, end] (inclusive, as unsigned longs) into the minimal
+     * list of CIDR blocks that covers exactly that range.
+     */
+    fun rangeToCidrs(start: Long, end: Long): List<Cidr> {
+        if (start > end) return emptyList()
+        val result = mutableListOf<Cidr>()
+        var cur = start
+
+        while (cur <= end) {
+            // Find the largest block that starts at cur and doesn't exceed end
+            var prefix = 32
+            while (prefix > 0) {
+                val newPrefix = prefix - 1
+                val mask = if (newPrefix == 0) 0L else ((-1L shl (32 - newPrefix)) and 0xFFFFFFFFL)
+                val blockStart = cur and mask
+                val blockEnd =
+                    if (newPrefix == 0) 0xFFFFFFFFL
+                    else blockStart + (1L shl (32 - newPrefix)) - 1
+                if (blockStart == cur && blockEnd <= end) {
+                    prefix = newPrefix
+                } else {
+                    break
+                }
+            }
+            result.add(Cidr(cur.toInt(), prefix))
+            val blockEnd =
+                if (prefix == 0) 0xFFFFFFFFL
+                else cur + (1L shl (32 - prefix)) - 1
+            cur = blockEnd + 1
+            if (cur > 0xFFFFFFFFL) break
+        }
+
+        return result
+    }
+
+    /**
+     * Subtracts all [excludeRanges] CIDR strings from a single [sourceCidr] string, returning the
+     * remaining non-overlapping CIDR strings.
+     */
+    fun subtractAll(sourceCidr: String, excludeRanges: Collection<String>): List<String> {
+        var remaining = listOf(parse(sourceCidr))
+        for (excl in excludeRanges) {
+            val excludeCidr = parse(excl)
+            remaining = remaining.flatMap { subtract(it, excludeCidr) }
+        }
+        return remaining.map { it.toString() }
+    }
+
+    /**
+     * Given a list of IPv4 AllowedIPs CIDR strings, returns a new list with all [lanRanges]
+     * excluded. IPv6 ranges (containing ':') are passed through unchanged.
+     *
+     * This is the main entry point for "LAN bypass" / Android Auto compatibility mode.
+     *
+     * @param allowedIps Original AllowedIPs (may include 0.0.0.0/0 or specific prefixes)
+     * @param lanRanges  Private/link-local ranges to exclude (e.g., "192.168.0.0/16")
+     * @return New AllowedIPs without the LAN ranges
+     */
+    fun applyLanBypass(allowedIps: List<String>, lanRanges: Collection<String>): List<String> {
+        if (lanRanges.isEmpty()) return allowedIps
+        return allowedIps.flatMap { cidr ->
+            if (cidr.contains(':')) {
+                // IPv6 — pass through as-is (handle separately if needed)
+                listOf(cidr)
+            } else {
+                subtractAll(cidr, lanRanges)
+            }
+        }.distinct()
+    }
+}

--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt
@@ -98,4 +98,19 @@ class SettingsViewModel(
     fun setAlreadyDonated(to: Boolean) = intent {
         settingsRepository.upsert(state.settings.copy(alreadyDonated = to))
     }
+
+    /**
+     * Enables or disables Android Auto / LAN bypass mode.
+     *
+     * When enabled, private/link-local subnets (192.168.x.x, 10.x.x.x, 172.16-31.x.x,
+     * 169.254.x.x, multicast) are excluded from WireGuard's AllowedIPs so they are
+     * not captured by the VPN tunnel. This allows Android Auto wireless projection,
+     * Chromecast, and local network access to work while the VPN is active.
+     *
+     * Any currently active tunnel must be restarted for this change to take effect.
+     */
+    fun setLanBypassEnabled(to: Boolean) = intent {
+        settingsRepository.upsert(state.settings.copy(isLanBypassEnabled = to))
+    }
 }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,4 +464,7 @@
     <string name="fdroid_url" translatable="false">https://apt.izzysoft.de/fdroid/index/apk/com.zaneschepke.wireguardautotunnel</string>
     <string name="import_url_description">The URL must be secure and serve a .conf file.</string>
     <string name="only_template">%1$s only</string>
+    <string name="lan_bypass">LAN bypass</string>
+    <string name="lan_bypass_description">Exclude private network ranges (192.168.x.x, 10.x.x.x, etc.) from the VPN tunnel. Required for Android Auto wireless, Chromecast, and local network access while the VPN is active. Internet traffic remains encrypted.</string>
 </resources>
+


### PR DESCRIPTION
## Fix: Android Auto wireless fails to reconnect while VPN is active

### Problem

When WG Tunnel is running in full-tunnel mode (`AllowedIPs = 0.0.0.0/0`),
Android's VPN routing captures **all** outbound packets — including the
local WiFi traffic Android Auto uses for wireless projection (`192.168.x.x`,
`169.254.x.x`, multicast). These packets get encrypted and forwarded to
the WireGuard server, which drops them (it has no route to the car's
subnet). Projection never establishes and the car head unit shows
"Waiting for phone".

Other VPNs (Tailscale, ZeroTier) are unaffected because they use
split-tunnel routing by default and never claim private IP ranges.

### Solution

Add an opt-in **LAN bypass** toggle (Settings → Android integrations).
When enabled, private/link-local ranges are excluded from `AllowedIPs`
via CIDR subtraction at tunnel startup — before the config is handed to
the backend. `VpnService.Builder.addRoute()` is therefore never called
for these ranges, so Android routes them directly over the physical WiFi
interface.

Excluded ranges:
```
10.0.0.0/8       (RFC-1918 class A)
172.16.0.0/12    (RFC-1918 class B)
192.168.0.0/16   (RFC-1918 class C — most car WiFi subnets)
169.254.0.0/16   (link-local, mDNS, ARP)
224.0.0.0/4      (multicast — mDNS uses 224.0.0.251)
```

Internet traffic continues to route encrypted through WireGuard. The
setting is **disabled by default** — no behavior change for existing users.

### Changes

| File | Change |
|------|--------|
| [util/network/CidrUtils.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/util/network/CidrUtils.kt:0:0-0:0) | New IPv4 CIDR subtraction utility |
| [domain/model/TunnelConfig.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/TunnelConfig.kt:0:0-0:0) | Add `LAN_EXCLUDED_RANGES` constant |
| [core/tunnel/backend/RunConfigHelper.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/tunnel/backend/RunConfigHelper.kt:0:0-0:0) | Rewrite `AllowedIPs` when LAN bypass is enabled (both WG and AM backends) |
| [domain/model/GeneralSettings.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/domain/model/GeneralSettings.kt:0:0-0:0) | Add `isLanBypassEnabled` field |
| [data/entity/GeneralSettings.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/entity/GeneralSettings.kt:0:0-0:0) | Add `is_lan_bypass_enabled` Room column |
| [data/AppDatabase.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/data/AppDatabase.kt:0:0-0:0) | Bump DB version 29 → 30, register AutoMigration |
| [viewmodel/SettingsViewModel.kt](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt:0:0-0:0) | Add [setLanBypassEnabled()](cci:1://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/java/com/zaneschepke/wireguardautotunnel/viewmodel/SettingsViewModel.kt:101:4-113:5) action |
| `ui/.../AndroidIntegrationsScreen.kt` | Add toggle in VPN settings section |
| [res/values/strings.xml](cci:7://file:///c:/Users/pc/projectw/wgtunnel/app/src/main/res/values/strings.xml:0:0-0:0) | Add label + description strings |

### Notes

- Requires tunnel restart after toggling (AllowedIPs are applied at startup)
- Compatible with Always-On VPN and Kill Switch / Lockdown mode
- Does **not** affect internet traffic encryption
- LAN traffic is only protected by the car's WPA2/WPA3 WiFi encryption (same as without VPN — acceptable tradeoff for local projection)

### Testing

1. Enable **LAN bypass** in Settings → Android integrations
2. Restart active tunnel
3. Connect phone via Android Auto Wireless
4. Verify projection connects ✅
5. Verify internet traffic still routes through WireGuard (`traceroute 8.8.8.8` shows WG server) ✅
