### PR TITLE
fix: debounce tunnel tile updates to prevent notification flicker

### DIFF
--- a/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/tunnel/handler/TunnelServiceHandler.kt
+++ b/app/src/main/java/com/zaneschepke/wireguardautotunnel/core/tunnel/handler/TunnelServiceHandler.kt
@@ -7,7 +7,9 @@ import com.zaneschepke.wireguardautotunnel.domain.state.TunnelState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -20,17 +22,20 @@ class TunnelServiceHandler(
 ) {
     init {
         applicationScope.launch(ioDispatcher) {
-            activeTunnels.collect { activeTuns ->
-                if (activeTuns.isEmpty()) {
-                    Timber.d("Stopping tunnel service, no tunnels active.")
-                    serviceManager.stopTunnelService()
-                } else if (serviceManager.tunnelService.value == null) {
-                    val settings = settingsRepository.flow.firstOrNull() ?: GeneralSettings()
-                    Timber.d("Starting tunnel foreground service for active tunnel.")
-                    serviceManager.startTunnelService(settings.appMode)
+            activeTunnels
+                .map { tunnels -> tunnels.mapValues { it.value.status } }
+                .distinctUntilChanged()
+                .collect { activeTuns ->
+                    if (activeTuns.isEmpty()) {
+                        Timber.d("Stopping tunnel service, no tunnels active.")
+                        serviceManager.stopTunnelService()
+                    } else if (serviceManager.tunnelService.value == null) {
+                        val settings = settingsRepository.flow.firstOrNull() ?: GeneralSettings()
+                        Timber.d("Starting tunnel foreground service for active tunnel.")
+                        serviceManager.startTunnelService(settings.appMode)
+                    }
+                    serviceManager.updateTunnelTile()
                 }
-                serviceManager.updateTunnelTile()
-            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`TunnelServiceHandler` calls `updateTunnelTile()` on every `activeTunnels` emission. Because stats are polled every ~1 second, this causes Android to continuously redraw the foreground service notification, producing visible flicker in the notification shade even when no meaningful state has changed.

## Fix

Map `activeTunnels` to status-only before collecting, then `distinctUntilChanged()` to suppress emissions where nothing changed. `updateTunnelTile()` now only fires on actual tunnel state transitions (tunnel added/removed, status change) — not on stats or ping updates.

```kotlin
activeTunnels
    .map { tunnels -> tunnels.mapValues { it.value.status } }
    .distinctUntilChanged()
    .collect { ... }
```

## Impact

- No behavior change for service start/stop logic
- Tile and notification only update when tunnel status actually changes
- Verified on 4.3.1 where the flicker was reproducible with an active tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)